### PR TITLE
Work on letterhead view

### DIFF
--- a/src/LetterheadCard.js
+++ b/src/LetterheadCard.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import { Card, CardTitle, CardActions, CardMedia } from 'material-ui/Card'
+import FlatButton from 'material-ui/FlatButton'
+
+class LetterheadCard extends Component {
+  render () {
+    return (
+      <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
+        <Card>
+          <CardMedia>
+            <img src={this.props.image} alt={this.props.title} />
+          </CardMedia>
+          <CardTitle title={this.props.title} />
+          <CardActions>
+            <FlatButton label={this.props.action} />
+          </CardActions>
+        </Card>
+      </div>
+    )
+  }
+}
+
+export default LetterheadCard

--- a/src/views/Letterhead.js
+++ b/src/views/Letterhead.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
-import { Card, CardTitle, CardActions, CardMedia } from 'material-ui/Card'
-import FlatButton from 'material-ui/FlatButton'
+import LetterheadCard from '../LetterheadCard'
 
 class Letterhead extends Component {
   render () {
@@ -29,51 +28,26 @@ class Letterhead extends Component {
           </div>
         </div>
         <div className='row'>
-          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
-            <Card>
-              <CardMedia>
-                <img src='https://unsplash.it/600/776/?random=1' alt='' />
-              </CardMedia>
-              <CardTitle title='Card title' />
-              <CardActions>
-                <FlatButton label='Action1' />
-              </CardActions>
-            </Card>
-          </div>
-          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
-            <Card>
-              <CardMedia>
-                <img src='https://unsplash.it/600/776/?random=2' alt='' />
-              </CardMedia>
-              <CardTitle title='Card title' />
-              <CardActions>
-                <FlatButton label='Action1' />
-              </CardActions>
-            </Card>
-          </div>
-          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
-            <Card>
-              <CardMedia>
-                <img src='https://unsplash.it/600/776/?random=3' alt='' />
-              </CardMedia>
-              <CardTitle title='Card title' />
-              <CardActions>
-                <FlatButton label='Action1' />
-              </CardActions>
-            </Card>
-          </div>
-
-          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
-            <Card>
-              <CardMedia>
-                <img src='https://unsplash.it/600/776/?random=4' alt='' />
-              </CardMedia>
-              <CardTitle title='Card title' />
-              <CardActions>
-                <FlatButton label='Action1' />
-              </CardActions>
-            </Card>
-          </div>
+          <LetterheadCard
+            title='Card title'
+            action='Action1'
+            image='https://unsplash.it/600/776/?random=1'
+          />
+          <LetterheadCard
+            title='Card title'
+            action='Action1'
+            image='https://unsplash.it/600/776/?random=2'
+          />
+          <LetterheadCard
+            title='Card title'
+            action='Action1'
+            image='https://unsplash.it/600/776/?random=3'
+          />
+          <LetterheadCard
+            title='Card title'
+            action='Action1'
+            image='https://unsplash.it/600/776/?random=4'
+          />
         </div>
       </div>
     )

--- a/src/views/Letterhead.js
+++ b/src/views/Letterhead.js
@@ -29,7 +29,7 @@ class Letterhead extends Component {
           </div>
         </div>
         <div className='row'>
-          <div className='col s12 m6'>
+          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
                 <img src='https://unsplash.it/600/776/?random' alt='' />
@@ -40,7 +40,7 @@ class Letterhead extends Component {
               </CardActions>
             </Card>
           </div>
-          <div className='col s12 m6'>
+          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
                 <img src='https://unsplash.it/600/776/?random' alt='' />
@@ -51,9 +51,7 @@ class Letterhead extends Component {
               </CardActions>
             </Card>
           </div>
-        </div>
-        <div className='row'>
-          <div className='col s12 m6'>
+          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
                 <img src='https://unsplash.it/600/776/?random' alt='' />
@@ -65,7 +63,7 @@ class Letterhead extends Component {
             </Card>
           </div>
 
-          <div className='col s12 m6'>
+          <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
                 <img src='https://unsplash.it/600/776/?random' alt='' />

--- a/src/views/Letterhead.js
+++ b/src/views/Letterhead.js
@@ -32,7 +32,7 @@ class Letterhead extends Component {
           <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
-                <img src='https://unsplash.it/600/776/?random' alt='' />
+                <img src='https://unsplash.it/600/776/?random=1' alt='' />
               </CardMedia>
               <CardTitle title='Card title' />
               <CardActions>
@@ -43,7 +43,7 @@ class Letterhead extends Component {
           <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
-                <img src='https://unsplash.it/600/776/?random' alt='' />
+                <img src='https://unsplash.it/600/776/?random=2' alt='' />
               </CardMedia>
               <CardTitle title='Card title' />
               <CardActions>
@@ -54,7 +54,7 @@ class Letterhead extends Component {
           <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
-                <img src='https://unsplash.it/600/776/?random' alt='' />
+                <img src='https://unsplash.it/600/776/?random=3' alt='' />
               </CardMedia>
               <CardTitle title='Card title' />
               <CardActions>
@@ -66,7 +66,7 @@ class Letterhead extends Component {
           <div className='col s12 m6' style={{ paddingBottom: '0.75rem' }}>
             <Card>
               <CardMedia>
-                <img src='https://unsplash.it/600/776/?random' alt='' />
+                <img src='https://unsplash.it/600/776/?random=4' alt='' />
               </CardMedia>
               <CardTitle title='Card title' />
               <CardActions>


### PR DESCRIPTION
The main thing is the refactored LetterheadCard component which replaces the card and the container for the card that was in the Letterhead view.

That way you don't have to copy-paste the className="col s12 m16" and all those things that get repeated a lot, and any change that you may want to do gets applied to all cards at once.

Also fixed the padding so that it works fine for small screens and as a bonus now every random image is different from one another.