### PR TITLE
Refactor ServiceRequest.js

### DIFF
--- a/src/views/ServiceRequest.js
+++ b/src/views/ServiceRequest.js
@@ -86,8 +86,8 @@ class ServiceRequest extends Component {
     this.handleInputChange = this.handleInputChange.bind(this)
   }
 
-  formatLabelToProperty = lable =>
-    lable.split(' (')[0].toLowerCase().split(' ').join('-')
+  formatLabelToProperty = label =>
+    label.split(' (')[0].toLowerCase().split(' ').join('-')
 
   handleInputChange (event) {
     const target = event.target

--- a/src/views/ServiceRequest.js
+++ b/src/views/ServiceRequest.js
@@ -43,16 +43,38 @@ class ServiceRequest extends Component {
       'Project Contact (if other than yourself)',
       'Comments'
     ]
-    const singleStateProps = this.singleLineFields.reduce(
+    this.leftCheckboxes = [
+      'Simple1',
+      'Simple2',
+      'Simple3',
+      'Simple4',
+      'Simple5',
+      'Simple6'
+    ]
+    this.rightCheckboxes = [
+      'Simple7',
+      'Simple8',
+      'Simple9',
+      'Simple10',
+      'Simple11',
+      'Simple12'
+    ]
+    const stringProps = [
+      ...this.singleLineFields,
+      ...this.multiLineFields
+    ].reduce(
       (acc, label) => ({
         [this.formatLabelToProperty(label)]: '',
         ...acc
       }),
       {}
     )
-    const multiStateProps = this.multiLineFields.reduce(
+    const checkboxProps = [
+      ...this.leftCheckboxes,
+      ...this.rightCheckboxes
+    ].reduce(
       (acc, label) => ({
-        [this.formatLabelToProperty(label)]: '',
+        [this.formatLabelToProperty(label)]: false,
         ...acc
       }),
       {}
@@ -60,7 +82,7 @@ class ServiceRequest extends Component {
     this.state = {
       fileInput: null
     }
-    Object.assign(this.state, singleStateProps, multiStateProps)
+    Object.assign(this.state, stringProps, checkboxProps)
     this.handleInputChange = this.handleInputChange.bind(this)
   }
 
@@ -118,6 +140,14 @@ class ServiceRequest extends Component {
           fullWidth
         />
       </div>
+    const CheckboxField = (label, index) =>
+      <Checkbox
+        label={label}
+        name={this.formatLabelToProperty(label)}
+        key={index}
+        onClick={this.handleInputChange}
+        style={styles.checkbox}
+      />
 
     return (
       <div className='container'>
@@ -158,22 +188,14 @@ class ServiceRequest extends Component {
             </div>
           </div>
           <div className='col s12 m6'>
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
+            {this.leftCheckboxes.map((label, index) =>
+              CheckboxField(label, index)
+            )}
           </div>
           <div className='col s12 m6'>
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
-            <Checkbox label='Simple' style={styles.checkbox} />
+            {this.rightCheckboxes.map((label, index) =>
+              CheckboxField(label, index)
+            )}
           </div>
           <div className='col s12'>
             <RaisedButton label='Submit' primary />

--- a/src/views/ServiceRequest.js
+++ b/src/views/ServiceRequest.js
@@ -32,14 +32,40 @@ const styles = {
 class ServiceRequest extends Component {
   constructor (props) {
     super(props)
+    this.singleLineFields = ['Name', 'Email', 'Phone', 'Department']
+    this.multiLineFields = [
+      'Project Description',
+      'Project Goal',
+      'Project Budget',
+      'Key Messages',
+      'Primary Target Audience',
+      'Secondary Target Audience',
+      'Project Contact (if other than yourself)',
+      'Comments'
+    ]
+    const singleStateProps = this.singleLineFields.reduce(
+      (acc, label) => ({
+        [this.formatLabelToProperty(label)]: '',
+        ...acc
+      }),
+      {}
+    )
+    const multiStateProps = this.multiLineFields.reduce(
+      (acc, label) => ({
+        [this.formatLabelToProperty(label)]: '',
+        ...acc
+      }),
+      {}
+    )
     this.state = {
-      fileInput: null,
-      name: '',
-      email: '',
-      phone: ''
+      fileInput: null
     }
+    Object.assign(this.state, singleStateProps, multiStateProps)
     this.handleInputChange = this.handleInputChange.bind(this)
   }
+
+  formatLabelToProperty = lable =>
+    lable.split(' (')[0].toLowerCase().split(' ').join('-')
 
   handleInputChange (event) {
     const target = event.target
@@ -69,7 +95,30 @@ class ServiceRequest extends Component {
   }
 
   render () {
-    let fileValue = this.state.fileInput || 'Select a file to upload'
+    const fileValue = this.state.fileInput || 'Select a file to upload'
+    const SingleLineField = (label, index) =>
+      <div className='col s12 m6' key={index}>
+        <TextField
+          floatingLabelText={label}
+          name={this.formatLabelToProperty(label)}
+          value={this.state[this.formatLabelToProperty(label)]}
+          onChange={this.handleInputChange}
+          fullWidth
+        />
+      </div>
+    const MultiLineField = (label, index) =>
+      <div className='col s12 m6' key={index}>
+        <TextField
+          floatingLabelText={label}
+          name={this.formatLabelToProperty(label)}
+          value={this.state[this.formatLabelToProperty(label)]}
+          onChange={this.handleInputChange}
+          multiLine
+          rows={2}
+          fullWidth
+        />
+      </div>
+
     return (
       <div className='container'>
         <div className='row'>
@@ -78,99 +127,12 @@ class ServiceRequest extends Component {
           </div>
         </div>
         <div className='row'>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Name'
-              name='name'
-              value={this.state.name}
-              onChange={this.handleInputChange}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Email'
-              name='email'
-              onChange={this.handleInputChange}
-              type='email'
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Phone'
-              name='phone'
-              onChange={this.handleInputChange}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField floatingLabelText='Department' fullWidth />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Project Description'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Project Goal'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Project Budget'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Key Messages'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Primary Target Audience'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Secondary Target Audience'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Project Contact (if other than yourself)'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
-          <div className='col s12 m6'>
-            <TextField
-              floatingLabelText='Comments'
-              multiLine
-              rows={2}
-              fullWidth
-            />
-          </div>
+          {this.singleLineFields.map((label, index) =>
+            SingleLineField(label, index)
+          )}
+          {this.multiLineFields.map((label, index) =>
+            MultiLineField(label, index)
+          )}
           <div className='col s12 m6'>
             <DatePicker hintText='Desired Completion Date' />
           </div>

--- a/src/views/testUtils.js
+++ b/src/views/testUtils.js
@@ -1,6 +1,13 @@
 import nightmare from 'nightmare'
+import url from 'url'
 
 export const visit = path => {
+  const BASE_URL = url.format({
+    protocol: process.env.PROTOCOL || 'http',
+    hostname: process.env.HOST || 'localhost',
+    port: process.env.PORT || 3000
+  })
+  const location = url.resolve(BASE_URL, path)
   const config = {
     // Try changing this to true and run the tests
     // It is pretty cool
@@ -10,5 +17,5 @@ export const visit = path => {
     // is only raised if the DOM itself has not yet loaded.
     gotoTimeout: 4000
   }
-  return nightmare(config).goto('http://localhost:3000' + path)
+  return nightmare(config).goto(location)
 }


### PR DESCRIPTION
I pulled out all the data for the single and multi line fields and refactored the markup to map over it. If you don't like the hyphens in the property names, or want to format them in some other way, they are all using a new formatLabelToProperty function, so you can just change it there. I initially was trying to use object spread to set the initial state, but for some reason, it wasn't updating with the default falsey values set, so I resorted to the old Object.assign. Oddly, object spread works fine in the reduce functions I wrote.