### PR TITLE
Remove hard-coded environment from testUtils.js

### DIFF
--- a/src/views/testUtils.js
+++ b/src/views/testUtils.js
@@ -1,6 +1,13 @@
 import nightmare from 'nightmare'
+import url from 'url'
 
 export const visit = path => {
+  const BASE_URL = url.format({
+    protocol: process.env.PROTOCOL || 'http',
+    hostname: process.env.HOST || 'localhost',
+    port: process.env.PORT || 3000
+  })
+  const location = url.resolve(BASE_URL, path)
   const config = {
     // Try changing this to true and run the tests
     // It is pretty cool
@@ -10,5 +17,5 @@ export const visit = path => {
     // is only raised if the DOM itself has not yet loaded.
     gotoTimeout: 4000
   }
-  return nightmare(config).goto('http://localhost:3000' + path)
+  return nightmare(config).goto(location)
 }


### PR DESCRIPTION
When I went to commit on the last PR, I had another project running on port 3000 and had accepted the devservers increment to port 3001 for the resource center work I wanted to do. Of course the tests failed since they were hitting my other project. I got around that the obvious way by killing my other projects server and restarting resource center.

I went in and fixed testUtils.js to read from the environment. Now you can either `echo "PORT=3001" > .env` or `PORT=3001 yarn test`. I didn't try `PORT=3000 git commit -m "My message"`, but that might work.