### PR TITLE
Test Service Request view

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "husky": "^0.14.3",
     "lint-staged": "^4.0.2",
     "nightmare": "^2.10.0",
+    "nightmare-upload": "^0.1.1",
     "prettier": "^1.5.3",
     "standard": "^10.0.2"
   },

--- a/src/views/ServiceRequest.js
+++ b/src/views/ServiceRequest.js
@@ -174,7 +174,7 @@ class ServiceRequest extends Component {
           <div className='col s12 m6'>
             <DatePicker hintText='Desired Completion Date' />
           </div>
-          <div className='col s12 m6'>
+          <div className='col s12 m6 file-upload'>
             <div className='file-field input-field'>
               <div className='btn'>
                 <span>Upload Files</span>
@@ -213,13 +213,17 @@ class ServiceRequest extends Component {
             <Checkbox label='Simple' style={styles.checkbox} />
             <Checkbox label='Simple' style={styles.checkbox} />
           </div>
-          <div className='col s12'>
+          <div className='col s12 planning-guide-checkbox'>
             <RaisedButton label='Submit' primary />
             <Checkbox
               label={
                 <span>
                   I have read the{' '}
-                  <Link to='/planning-guide' style={{ fontWeight: 500 }}>
+                  <Link
+                    to='/planning-guide'
+                    target='_blank'
+                    style={{ fontWeight: 500 }}
+                  >
                     Planning Guide
                   </Link>
                 </span>

--- a/src/views/ServiceRequest.test.js
+++ b/src/views/ServiceRequest.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+import { visit } from './testUtils'
+
+describe('Service Request Page', () => {
+  it('loads on /service-request-form', async () => {
+    const page = visit('/service-request-form')
+    await page.end()
+  })
+
+  it('contains the text "Please use this form to request services"', async () => {
+    const page = visit('/service-request-form')
+    const text = await page.evaluate(() => document.body.textContent).end()
+
+    expect(text).toContain('Please use this form to request services')
+  })
+
+  it('contains a bunch(10+) of input fields', async () => {
+    const page = visit('/service-request-form')
+    const inputFieldCount = await page
+      .evaluate(() => document.getElementsByTagName('input').length)
+      .end()
+
+    expect(inputFieldCount).toBeGreaterThanOrEqual(10)
+  })
+
+  it('does not navigate away when clicking on Planning Guide (modal or new tab)', async () => {
+    const page = visit('/service-request-form')
+    const linkSelector = '.planning-guide-checkbox a'
+    const path = await page.click(linkSelector).path().end()
+
+    expect(path).toEqual('/service-request-form')
+  })
+
+  it('does not checks the checkbox when clicking on Planning Guide', async () => {
+    const page = visit('/service-request-form')
+    const linkSelector = '.planning-guide-checkbox a'
+    const checkboxSelector = '.planning-guide-checkbox input[type="checkbox"]'
+    const checked = await page
+      .click(linkSelector)
+      .evaluate(sel => document.querySelector(sel).checked, checkboxSelector)
+      .end()
+
+    expect(checked).toEqual(false)
+  })
+
+  it('allows to upload files and shows the filenames', async () => {
+    let page = visit('/service-request-form')
+    const fileInputSelector = '.file-upload input[type="file"]'
+    const filenamesSelector =
+      '.file-upload .file-path-wrapper > input[type="text"]'
+    const text = await page
+      .upload(fileInputSelector, ['fake file 1.txt', 'fake file 2.txt'])
+      .evaluate(sel => document.querySelector(sel).value, filenamesSelector)
+      .end()
+
+    expect(text).toEqual('fake file 1.txt, fake file 2.txt')
+  })
+})

--- a/src/views/testUtils.js
+++ b/src/views/testUtils.js
@@ -1,4 +1,5 @@
-import nightmare from 'nightmare'
+import Nightmare from 'nightmare'
+require('nightmare-upload')(Nightmare)
 
 export const visit = path => {
   const config = {
@@ -10,5 +11,6 @@ export const visit = path => {
     // is only raised if the DOM itself has not yet loaded.
     gotoTimeout: 4000
   }
-  return nightmare(config).goto('http://localhost:3000' + path)
+  const nightmare = Nightmare(config)
+  return nightmare.goto('http://localhost:3000' + path)
 }


### PR DESCRIPTION
Some more testing!

- Added some classes to a couple ServiceRequest components to ease testing
- Made so that the planning guide link opens a new tab
- Testing some basic things in the ServiceRequest view
- Testing file upload (was not that basic, the code turned out pretty well though)

Update packages again (sorry). Nightmare used to have a way to fill out file inputs but when it changed its underliyng technology to [Electron](https://electron.atom.io/) it dropped support for that, then they found a way to do it but it was done as an external package ([nightmare-upload](https://github.com/rosshinkley/nightmare-upload)) more on that in [this issue for nightmare](https://github.com/segmentio/nightmare/issues/235).