### PR TITLE
Better server

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "watch-css": "npm run build-css && node-sass-chokidar --include-path ./src --include-path ./node_modules src/ -o src/ --watch --recursive",
     "start-js": "react-scripts start",
     "start": "npm-run-all -p watch-css start-js",
+    "custom-server-only": "nodemon server.js",
+    "custom-server": "react-scripts build && npm-run-all -p watch-css custom-server-only",
     "build": "npm run build-css && react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "test-without-watch": "cross-env CI=true npm test",
@@ -31,6 +33,7 @@
     "nightmare": "^2.10.0",
     "nightmare-upload": "^0.1.1",
     "node-sass-chokidar": "^0.0.3",
+    "nodemon": "^1.11.0",
     "npm-run-all": "^4.0.2",
     "prettier": "^1.5.3",
     "standard": "^10.0.2"

--- a/server.js
+++ b/server.js
@@ -2,6 +2,11 @@ const express = require('express')
 const path = require('path')
 const formidable = require('formidable')
 const app = express()
+const fs = require('fs')
+
+const uploadDir = path.join(__dirname, 'uploads')
+
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir)
 
 app.use(express.static(path.join(__dirname, 'build')))
 
@@ -15,7 +20,7 @@ app.post('/uploads', function (req, res) {
   form.parse(req)
 
   form.on('fileBegin', function (name, file) {
-    file.path = `${__dirname}'/uploads/'${file.name}`
+    file.path = `${uploadDir}/${file.name}`
   })
 
   form.on('file', function (name, file) {

--- a/server.js
+++ b/server.js
@@ -25,4 +25,4 @@ app.post('/uploads', function (req, res) {
   res.json({ success: true, status: 'Form successfully﻿ submitted' })
 })
 
-app.listen(9000)
+app.listen(9000, () => console.log('Now serving on http://localhost:9000'))


### PR DESCRIPTION
- Added `npm run custom-server`. It builds, then runs the server and watches css and the server itself. The server auto-restarts when you make a change to it.
- Show a message when the server starts. (Just a blank command line doesn't seems like its working).
- Create uploads folder if it doesn't exist. Normally the sync versions of fs functions are discouraged because they block the server until they are done, but in this case is fine because this only happens once at server start.

You have to do `npm install` for nodemon.