### PR TITLE
Use .env to determine whether to send emails or not

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Environment
+NODE_ENV=development
+
+# API Keys
+SENDGRID_API_KEY=<your sendgrid api key here>
+
+# URL Settings
+PROTOCOL=http
+HOSTNAME=localhost
+PORT=3000
+SERVER_PORT=9000
+
+# Server Configurations
+ENABLE_SEND_EMAILS=false

--- a/src/server.test.js
+++ b/src/server.test.js
@@ -20,7 +20,7 @@ async function post (data, customHeaders) {
       customHeaders
     ),
     method: 'post',
-    body: data + '&testing=true'
+    body: data
   })
 
   return res.json()


### PR DESCRIPTION
I previously used an special query parameter to inform the server that the request was only a test and it should not send an email.
That fails because there are tests that use the page normally through a browser, while using the page normally you can't attach extra parameters to the request.

So here is another approach: configure the server itself to not send emails at all using an environment variable. In the case you need the server to actually send emails (while testing that feature or in production) just change the .env file.

Added a .env.example file for people cloning the repo.
The .env file can't be in source control because it contains api keys, database passwords and other secret stuff. But you can share an example file so that people know what is the .env supposed to look like and where to put their own api keys and other details.