### PR TITLE
Refactor add attachment logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "formidable": "^1.1.1",
-    "fs-extra": "^4.0.1",
     "material-ui": "^0.18.6",
     "nodemon": "^1.11.0",
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "formidable": "^1.1.1",
+    "fs-extra": "^4.0.1",
     "material-ui": "^0.18.6",
     "nodemon": "^1.11.0",
     "react": "^15.6.1",


### PR DESCRIPTION
- Use a variable for the folder ID
- Add fs-extra. Update add attachment code to use promises.
- Remove fs-extra. Use a ReadableStream instead of a Buffer also removing the need for promises and callbacks altogether on reading the file.
This is probably not a performance improvement because node-fetch has to read the file anyway but the code is a little bit nicer.