### PR TITLE
Fix logos moving around when clicking on tabs

### DIFF
--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -57,7 +57,7 @@ class Logos extends Component {
 
         {/* For each tab, we generate a row */}
         {Object.keys(tabs).map(tabKey =>
-          <div className='row' id={tabKey} key={tabKey}>
+          <div className='row' style={{ marginBottom: 0 }} key={tabKey}>
             {/* We render masonry comp only if we are in current active tab key */}
             {activeTab === tabKey && massonryComp}
           </div>


### PR DESCRIPTION
- Removed the id because when you click on a link with #something at the end the browser scrolls to the element with id something and the tabs were being left up outside the viewport on each click (when there is enough images to actually scroll down).
- Added margin-bottom to .row elements containing logos because when they were empty they anyway has a margin and occupied space in the screen between the tabs and the logos.