### PR TITLE
Added testing related globals to standard configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,11 @@
   "standard": {
     "globals": [
       "fetch",
-      "FormData"
+      "FormData",
+      "describe",
+      "it",
+      "beforeEach",
+      "expect"
     ],
     "parser": "babel-eslint"
   }


### PR DESCRIPTION
When trying to commit I kept getting errors from standard that 'describe, it, expect and beforeEach' were not defined. Since these keywords are defined globally, i added them to the globals property so they would be ignored.