### PR TITLE
Layout fix.

### DIFF
--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -1,8 +1,8 @@
-.col {
+.flex-div {
   display: flex;
   margin-bottom: 16px;
 
-  >div {
+  div {
     display: flex;
     flex-direction: column;
     flex-grow: 1;

--- a/src/styles/logos.scss
+++ b/src/styles/logos.scss
@@ -30,7 +30,9 @@ $link-color: $fus-yellow;
     border-top: 1px solid rgba(160,160,160,0.2);
   }
 
-  button {
+  a {
+    width: 50%;
+
     span {
       color: $link-color;
 

--- a/src/styles/serviceRequest.scss
+++ b/src/styles/serviceRequest.scss
@@ -1,0 +1,13 @@
+.col {
+    display: block;
+    margin-bottom: 16px;
+  
+    >div {
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+    }
+}
+#planning-guide-checkbox {
+  padding-top: 15px;
+}

--- a/src/styles/serviceRequest.scss
+++ b/src/styles/serviceRequest.scss
@@ -1,13 +1,3 @@
-.col {
-    display: block;
-    margin-bottom: 16px;
-  
-    >div {
-      display: flex;
-      flex-direction: column;
-      flex-grow: 1;
-    }
-}
 #planning-guide-checkbox {
   padding-top: 15px;
 }

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -27,34 +27,34 @@ class Home extends Component {
       >
         <div className='row' style={{ display: 'flex', flexWrap: 'wrap' }}>
           <h2 style={{ flex: '1 100%' }}>Hello! How can MarCom help you?</h2>
-          <div className='col s12 m4'>
+          <div className='col s12 m4 flex-div'>
             <GenericCard cardTitle='Brand Manual'>
               Visual Brand Identity Manual
             </GenericCard>
           </div>
-          <div className='col s12 m4'>
+          <div className='col s12 m4 flex-div'>
             <GenericCard cardTitle='Logos and Posters'>
               Official Franciscan University Logos and Poster Resources
             </GenericCard>
           </div>
-          <div className='col s12 m4'>
+          <div className='col s12 m4 flex-div'>
             <GenericCard cardTitle='Letterhead'>
               Franciscan University approved letterhead and letter writing
               guidelines
             </GenericCard>
           </div>
-          <div className='col s12 m4'>
+          <div className='col s12 m4 flex-div'>
             <GenericCard cardTitle='Suggest a Story'>
               Help us share your news.
             </GenericCard>
           </div>
-          <div className='col s12 m4'>
+          <div className='col s12 m4 flex-div'>
             <GenericCard cardTitle='Service Request Form'>
               Let us know what you need, and we will get started on it as soon
               as we can.
             </GenericCard>
           </div>
-          <div className='col s12 m4'>
+          <div className='col s12 m4 flex-div'>
             <GenericCard cardTitle='Powerpoint'>
               Official Franciscan University Powerpoint temlate
             </GenericCard>

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -71,7 +71,7 @@ class Logos extends Component {
                         'https://myfranciscan.franciscan.edu/ICS/clientconfig/customcontent/marcom/MarComTab/' +
                         logo.psdUrl
                       }
-                      download
+                      download={logo.name}
                       label={
                         <span>
                           <DownloadIcon color='#ffb41f' />PSD

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -113,7 +113,7 @@ class Logos extends Component {
               floatingLabelText='Logo Type'
               value={this.state.activeTab}
               onChange={this.handleChange}
-              style={{ textAlign: 'left' }}
+              style={{ textAlign: 'left', width: '100%' }}
             >
               {Object.keys(tabs).map(tabKey =>
                 <MenuItem

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -55,6 +55,11 @@ class Logos extends Component {
                 actions={
                   <div>
                     <FlatButton
+                      href={
+                        'https://myfranciscan.franciscan.edu/ICS/clientconfig/customcontent/marcom/MarComTab/' +
+                        logo.jpgUrl
+                      }
+                      download
                       label={
                         <span>
                           <DownloadIcon color='#ffb41f' />JPG
@@ -62,6 +67,11 @@ class Logos extends Component {
                       }
                     />
                     <FlatButton
+                      href={
+                        'https://myfranciscan.franciscan.edu/ICS/clientconfig/customcontent/marcom/MarComTab/' +
+                        logo.psdUrl
+                      }
+                      download
                       label={
                         <span>
                           <DownloadIcon color='#ffb41f' />PSD
@@ -106,7 +116,11 @@ class Logos extends Component {
               style={{ textAlign: 'left' }}
             >
               {Object.keys(tabs).map(tabKey =>
-                <MenuItem value={tabKey} primaryText={tabs[tabKey]} />
+                <MenuItem
+                  value={tabKey}
+                  primaryText={tabs[tabKey]}
+                  key={tabKey}
+                />
               )}
             </SelectField>
           </div>

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -59,7 +59,7 @@ class Logos extends Component {
                         'https://myfranciscan.franciscan.edu/ICS/clientconfig/customcontent/marcom/MarComTab/' +
                         logo.jpgUrl
                       }
-                      download
+                      download={logo.name}
                       label={
                         <span>
                           <DownloadIcon color='#ffb41f' />JPG

--- a/src/views/ServiceRequest.js
+++ b/src/views/ServiceRequest.js
@@ -7,6 +7,7 @@ import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
 import { Link } from 'react-router-dom'
 import '../styles/inputFile.css'
+import '../styles/serviceRequest.css'
 
 const PORT = process.env.UPLOADS_PORT || 9000
 const HOST = process.env.UPLOADS_HOST || window.location.host.split(':')[0]


### PR DESCRIPTION
Changelog:
1. Fixed a layout issue on `/service-request-form` and a few other caused by the `home.css`. When importing `.css` files in components, when the site is built all the styles are applied, so when certain style is duplicated with different values the last one is applied. Do not use style the same class/tag in different `.css` files because only the last one will be applied. Better add a new class. Same thing when directly stilling HTML tags.
2. The download buttons in `/logos` now downloads the desired file. Filename is applied from logoData.js
3. The buttons in /logos are now `<a>` tags (due to point 2). Necessary styling was applied in order to look how they were.
4. ` /logos` buttons now occupy half the width of the card. Looks better in my opinion.
5. `<SelectField>` in `/logos` now has a width of 100%.

NOTE: Some of this changes are optional and up to you if you want them or not. Also, I had to bypass the tests again (sometimes they pass and sometimes they don't) so I don't know if the files were linted or no.