### PR TITLE
Added "package-lock.json" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # misc
 .DS_Store
+package-lock.json
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
This pull request adds package-lock.json to the .gitignore file. Atom's Git helper will nag you to commit it overwise.