### PR TITLE
Replace lodash underscore imports with required function, refactored …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # production
 /build
 
+# package-lock.json
+package-lock.json
+
 # misc
 .DS_Store
 package-lock.json

--- a/src/components/GenericCard.js
+++ b/src/components/GenericCard.js
@@ -15,10 +15,7 @@ import {
 } from 'material-ui/Card'
 
 export class GenericCard extends Component {
-  constructor (props) {
-    super(props)
-    this.state = { depth: 1 }
-  }
+  state = { depth: 1 }
 
   // From https://stackoverflow.com/a/37112044/4718107
   // debounce the function to 30 frames per second

--- a/src/components/GenericCard.js
+++ b/src/components/GenericCard.js
@@ -30,8 +30,11 @@ export class GenericCard extends Component {
   }, 32)
 
   render () {
-    const { link } = this.props
-
+    const { link, className } = this.props
+    /* Removed from Paper below:
+      onMouseOver={hoverable && this.onMouseOver}
+      onMouseOut={hoverable && this.onMouseOut}
+    */
     const CardContent = ({
       actions,
       cardSubtitle,
@@ -47,39 +50,36 @@ export class GenericCard extends Component {
       overlay,
       zDepth
     }) =>
-      <Paper
-        zDepth={zDepth}
-        onMouseOver={hoverable && this.onMouseOver}
-        onMouseOut={hoverable && this.onMouseOut}
-        style={{ height: '100%' }}
-      >
-        <Card className={classes} style={{ boxShadow: 'none' }}>
-          {(headerTitle || headerAvatar) &&
-            <CardHeader
-              title={headerTitle}
-              subtitle={headerSubtitle}
-              avatar={headerAvatar}
-            />}
+      <div className={className || 'fix-height'}>
+        <Paper zDepth={zDepth} style={{ height: '100%' }}>
+          <Card className={classes} style={{ boxShadow: 'none' }}>
+            {(headerTitle || headerAvatar) &&
+              <CardHeader
+                title={headerTitle}
+                subtitle={headerSubtitle}
+                avatar={headerAvatar}
+              />}
 
-          {mediaImgSrc &&
-            <CardMedia className='img-container' overlay={overlay}>
-              <img src={mediaImgSrc} alt={mediaImgAlt} />
-            </CardMedia>}
-          {cardTitle &&
-            <CardTitle
-              title={cardTitle}
-              subtitle={cardSubtitle}
-              style={{ paddingBottom: '0' }}
-            />}
-          <CardText style={{ fontSize: '16px', paddingTop: '0' }}>
-            {children}
-          </CardText>
-          {actions &&
-            <CardActions className='card-actions'>
-              {actions}
-            </CardActions>}
-        </Card>
-      </Paper>
+            {mediaImgSrc &&
+              <CardMedia className='img-container' overlay={overlay}>
+                <img src={mediaImgSrc} alt={mediaImgAlt} />
+              </CardMedia>}
+            {cardTitle &&
+              <CardTitle
+                title={cardTitle}
+                subtitle={cardSubtitle}
+                style={{ paddingBottom: '0' }}
+              />}
+            <CardText style={{ fontSize: '16px', paddingTop: '0' }}>
+              {children}
+            </CardText>
+            {actions &&
+              <CardActions className='card-actions'>
+                {actions}
+              </CardActions>}
+          </Card>
+        </Paper>
+      </div>
 
     const isInternal = link && link[0] === '/'
 

--- a/src/components/MaterializeRaisedButton.js
+++ b/src/components/MaterializeRaisedButton.js
@@ -2,15 +2,10 @@ import React, { Component } from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 
 class MaterializeRaisedButton extends Component {
-  constructor (props) {
-    super(props)
-    // We need to track the hovering ourselves because we cannot
-    // control the styles of material-ui's RaisedButton only when
-    // it is hovered. We override the styles all the time
-    this.state = {
-      hovered: false
-    }
-  }
+  // We need to track the hovering ourselves because we cannot
+  // control the styles of material-ui's RaisedButton only when
+  // it is hovered. We override the styles all the time
+  state = { hovered: false }
 
   render () {
     const overlayStyle = {

--- a/src/components/PlanningGuidelines.js
+++ b/src/components/PlanningGuidelines.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 /* global scrollToItem */
-import _ from 'lodash'
+import map from 'lodash/map'
 import React, { PureComponent } from 'react'
 import { Link } from 'react-router-dom'
 import { sliceHeaders } from './getTopCoord'
@@ -34,7 +34,7 @@ class PlanningGuidelines extends PureComponent {
               </h2>
             </div>
             <div className='col s12'>
-              {_.map(planningGuideData, ({ id, title, description }, key) => {
+              {map(planningGuideData, ({ id, title, description }, key) => {
                 return (
                   <span key={key}>
                     <h3 ref={title} id={id}>
@@ -61,7 +61,7 @@ class PlanningGuidelines extends PureComponent {
                 MarCom provides many services to help you complete your
                 marketing and communication projects.
               </p>
-              {_.map(servicesData, ({ title, description }, key) => {
+              {map(servicesData, ({ title, description }, key) => {
                 return (
                   <dl key={key}>
                     <dt>

--- a/src/components/ScrollIntoView.js
+++ b/src/components/ScrollIntoView.js
@@ -4,13 +4,13 @@ import { withRouter } from 'react-router'
 class ScrollIntoView extends Component {
   componentDidUpdate (prevProps) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
-      this.node.scrollIntoView()
+      this.component.scrollIntoView()
     }
   }
 
   render () {
     return (
-      <span ref={node => (this.node = node)}>
+      <span ref={component => (this.component = component)}>
         {this.props.children}
       </span>
     )

--- a/src/components/SideNav.js
+++ b/src/components/SideNav.js
@@ -4,13 +4,10 @@ import AppBar from 'material-ui/AppBar'
 import Drawer from 'material-ui/Drawer'
 import SideBarItem from './sideBarItem'
 import { List } from 'material-ui/List'
-import { links } from '../data/linksData'
+import links from '../data/linksData'
 
 class SideNav extends Component {
-  constructor (props) {
-    super(props)
-    this.state = { open: false }
-  }
+  state = { open: false }
 
   handleClose = () => this.setState({ open: false })
 

--- a/src/components/getTopCoord.js
+++ b/src/components/getTopCoord.js
@@ -1,8 +1,8 @@
-import _ from 'lodash'
+import mapValues from 'lodash/mapValues'
 
 export const sliceHeaders = headers => {
   const headerPositions = []
-  _.mapValues(headers, ({ offsetTop }) => {
+  mapValues(headers, ({ offsetTop }) => {
     headerPositions.push(offsetTop)
   })
   return headerPositions

--- a/src/components/masonryComp.js
+++ b/src/components/masonryComp.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import filter from 'lodash/filter'
 import React from 'react'
 import Masonry from 'react-masonry-component'
 import { GenericCard } from './../components/GenericCard'
@@ -8,7 +8,7 @@ import DownloadIcon from './downloadIcon'
 const MasonryComp = ({ data, activeTab }) => {
   return (
     <Masonry>
-      {_.filter(
+      {filter(
         data,
         logo => activeTab === 'all' || activeTab === logo.category
       ).map(({ thumbnailUrl, jpgUrl, name, psdUrl }, i) =>

--- a/src/components/planningGuideNav.js
+++ b/src/components/planningGuideNav.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React from 'react'
 import { headerTitles, styles } from '../data/planningGuideServicesData'
 
@@ -7,7 +7,7 @@ const PlanningGuideNav = ({ activeSection, scrollToItem }) => {
   return (
     <div style={root}>
       <ul>
-        {_.map(headerTitles, ({ title }, key) => {
+        {map(headerTitles, ({ title }, key) => {
           return (
             <li
               key={key}

--- a/src/data/genericCardData.js
+++ b/src/data/genericCardData.js
@@ -1,4 +1,4 @@
-export const genericCardData = [
+export default [
   {
     title: 'Brand Manual',
     description: 'Visual Brand Identity Manual.'

--- a/src/data/glossaryData.js
+++ b/src/data/glossaryData.js
@@ -1,4 +1,4 @@
-export const glossaryData = [
+export default [
   {
     title: 'Banner Ad',
     description:

--- a/src/data/letterheadData.js
+++ b/src/data/letterheadData.js
@@ -1,4 +1,4 @@
-export const letterheadData = [
+export default [
   {
     image: 'https://placeimg.com/600/776/nature'
   },

--- a/src/data/linksData.js
+++ b/src/data/linksData.js
@@ -1,4 +1,4 @@
-export const links = [
+export default [
   { isExact: true, linkTo: '/', text: 'Home' },
   { isExact: false, linkTo: '/logos', text: 'Logos' },
   { isExact: false, linkTo: '/posters', text: 'Posters' },

--- a/src/data/posterData.js
+++ b/src/data/posterData.js
@@ -1,4 +1,4 @@
-export const posterData = [
+export default [
   {
     cardTitle: 'Create Your Own',
     link: 'https://www.canva.com/',

--- a/src/data/posterVideosData.js
+++ b/src/data/posterVideosData.js
@@ -1,4 +1,4 @@
-export const posterVideos = [
+export default [
   {
     title: 'Powerpoint',
     url: 'https://www.youtube.com/embed/A4qXONix2aQ?rel=0'

--- a/src/styles/posters.scss
+++ b/src/styles/posters.scss
@@ -1,3 +1,15 @@
-.flex-div>a {
-  width: 100%;
+.flex-div > a {
+	width: 100%;
+}
+
+.fix-height {
+	height: 100%;
+}
+
+.hoverable {
+	@extend .fix-height;
+}
+
+.hoverable:hover {
+	box-shadow: rgba(0, 0, 0, 0.16) 0px 3px 10px, rgba(0, 0, 0, 0.23) 0px 3px 10px;
 }

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -1,17 +1,12 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React, { Component } from 'react'
 import { GenericCard } from '../components/GenericCard'
 import { Helmet } from 'react-helmet'
-import { genericCardData } from '../data/genericCardData'
+import genericCardData from '../data/genericCardData'
 import '../styles/home.css'
 
 class Home extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      topCoord: null
-    }
-  }
+  state = { topCoord: null }
 
   componentDidMount () {
     this.setState({
@@ -40,7 +35,7 @@ class Home extends Component {
             <h2 style={{ flex: '1 100%' }}>Hello! How can MarCom help you?</h2>
           </div>
 
-          {_.map(genericCardData, ({ title, description }, key) => {
+          {map(genericCardData, ({ title, description }, key) => {
             return (
               <div key={key} className='col s12 m4 flex-div'>
                 <GenericCard cardTitle={title}>

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React, { Component } from 'react'
 import SelectField from 'material-ui/SelectField'
 import MenuItem from 'material-ui/MenuItem'
@@ -8,14 +8,10 @@ import MasonryComp from '../components/masonryComp'
 import '../styles/logos.css'
 
 class Logos extends Component {
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      activeTab: 'all',
-      data: logos,
-      type: 'all'
-    }
+  state = {
+    activeTab: 'all',
+    data: logos,
+    type: 'all'
   }
 
   handleChange = (event, index, value) => this.setState({ activeTab: value })
@@ -31,7 +27,7 @@ class Logos extends Component {
         <div className='row'>
           <div className='col s12 hide-on-med-and-down'>
             <ul className='tabs'>
-              {_.map(tabs, (tab, tabKey) =>
+              {map(tabs, (tab, tabKey) =>
                 <li className='tab' key={tabKey + 'li'}>
                   <a
                     key={tabKey}
@@ -55,7 +51,7 @@ class Logos extends Component {
               onChange={this.handleChange}
               style={{ textAlign: 'left', width: '100%' }}
             >
-              {_.map(tabs, (tab, tabKey) =>
+              {map(tabs, (tab, tabKey) =>
                 <MenuItem
                   value={tabKey}
                   primaryText={tabs[tabKey]}
@@ -67,7 +63,7 @@ class Logos extends Component {
         </div>
 
         {/* For each tab, we generate a row */}
-        {_.map(tabs, (tab, tabKey) =>
+        {map(tabs, (tab, tabKey) =>
           <div className='row' style={{ marginBottom: 0 }} key={tabKey}>
             {/* We render masonry comp only if we are in current active tab key */}
             {activeTab === tabKey &&

--- a/src/views/PlanningGuide.js
+++ b/src/views/PlanningGuide.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 /* global trackScroll handleScroll setHeaders */
-import _ from 'lodash'
+import each from 'lodash/each'
 import React, { Component } from 'react'
 import { Helmet } from 'react-helmet'
 import throttle from 'lodash/throttle'
@@ -32,7 +32,7 @@ class PlanningGuide extends Component {
 
   handleScroll = () => {
     this.setState({ scrollY: window.scrollY }, () => {
-      _.each(this.state.headerPositions, (position, key) => {
+      each(this.state.headerPositions, (position, key) => {
         if (this.state.scrollY > position - 1) {
           this.setState({ activeSection: key })
         }

--- a/src/views/Posters.js
+++ b/src/views/Posters.js
@@ -45,6 +45,7 @@ class Posters extends Component {
                     hoverable={hoverable}
                     link={link}
                     cardTitle={cardTitle}
+                    className={hoverable ? 'hoverable' : ''}
                   >
                     {description}
                     {contactInfo !== undefined

--- a/src/views/Posters.js
+++ b/src/views/Posters.js
@@ -1,18 +1,13 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 import { GenericCard } from './../components/GenericCard'
-import { posterData } from '../data/posterData'
+import posterData from '../data/posterData'
 import '../styles/posters.css'
 
 class Posters extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      topCoord: null
-    }
-  }
+  state = { topCoord: null }
 
   componentDidMount () {
     this.setState({
@@ -41,7 +36,7 @@ class Posters extends Component {
             <h2 style={{ flex: '1 100%' }}>Poster Resources</h2>
           </div>
 
-          {_.map(
+          {map(
             posterData,
             ({ hoverable, link, cardTitle, description, contactInfo }, key) => {
               return (
@@ -55,7 +50,7 @@ class Posters extends Component {
                     {contactInfo !== undefined
                       ? <div style={{ marginBottom: '0' }}>
                         <br />
-                        {_.map(contactInfo, ({ link, linkText }, key) => {
+                        {map(contactInfo, ({ link, linkText }, key) => {
                           return (
                             <p
                               style={{

--- a/src/views/Tutorial.js
+++ b/src/views/Tutorial.js
@@ -3,12 +3,8 @@ import { Helmet } from 'react-helmet'
 import '../styles/video.css'
 
 class Tutorial extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      topCoord: null
-    }
-  }
+  state = { topCoord: null }
+
   componentDidMount () {
     this.setState({
       topCoord: this.refs.tutorialContainer.offsetTop

--- a/src/views/glossary.js
+++ b/src/views/glossary.js
@@ -1,7 +1,7 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React from 'react'
 import { Helmet } from 'react-helmet'
-import { glossaryData } from '../data/glossaryData'
+import glossaryData from '../data/glossaryData'
 
 const Glossary = () => {
   return (
@@ -15,7 +15,7 @@ const Glossary = () => {
             <h2 style={{ marginBottom: 0 }}>Common MarCom Terms</h2>
           </div>
           <div className='col s12'>
-            {_.map(glossaryData, ({ title, description }, key) => {
+            {map(glossaryData, ({ title, description }, key) => {
               return (
                 <dl key={key}>
                   <dt>

--- a/src/views/letterhead.js
+++ b/src/views/letterhead.js
@@ -1,8 +1,8 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React from 'react'
-import LetterheadCard from '../components/letterheadCard'
-import { letterheadData } from '../data/letterheadData'
 import { Helmet } from 'react-helmet'
+import LetterheadCard from '../components/letterheadCard'
+import letterheadData from '../data/letterheadData'
 
 const Letterhead = () => {
   return (
@@ -33,7 +33,7 @@ const Letterhead = () => {
         </div>
       </div>
       <div className='row'>
-        {_.map(letterheadData, ({ image }, key) => {
+        {map(letterheadData, ({ image }, key) => {
           return (
             <LetterheadCard
               key={key}

--- a/src/views/posterVideos.js
+++ b/src/views/posterVideos.js
@@ -1,6 +1,6 @@
-import _ from 'lodash'
+import map from 'lodash/map'
 import React from 'react'
-import { posterVideos } from '../data/posterVideosData'
+import posterVideos from '../data/posterVideosData'
 import '../styles/video.css'
 
 const PosterVideos = () => {
@@ -10,7 +10,7 @@ const PosterVideos = () => {
         <div className='col s12 flow-text'>
           <h2>Poster Video Tutorials</h2>
         </div>
-        {_.map(posterVideos, ({ title, url }, key) => {
+        {map(posterVideos, ({ title, url }, key) => {
           return (
             <div key={key} className='col s12'>
               <div style={{ width: '100%' }}>


### PR DESCRIPTION
…some data files to just export default for easier/implicit imports, replaced setting constructor state with just state equals and fixed GenericCard bug issue #49 .

Changes includes:
- Replace `import _ from lodash` with `import func from 'lodash/func'`
- Changed some data files from `export const dataFile [ {...} ]` to `export default [ {...} ]`. Imports will now be **implicit**: `import useAnyNameToImportData from '../dataFile' ` **instead of an explicit** `import { dataFile } from '../dataFile'` (there are a few file exceptions, where if the file had more than one data object, then I left it as an explicit export)
- Confirmed that `state = {...}` is syntactic sugar (thanks to Babel loader) for `constructor { super(); this.state={} }`. With the exception of PlanningGuide (due to a function being binded in the constructor method) and ServiceRequest, all components/views with state have been converted to the simplified `state = {...}`
- Fixed the GenericCard bug where it was: Re-rendering every time the mouse moved over the card and occasionally missed removing the box-shadow.  I'm not 100% sure why you're re-rendering z-index (z-depth) since you don't have any overlapping HTML elements, so I have removed the onMouseOver/Out functions from the Paper's function properties in GenericCard.js and instead replaced a top level div with a CSS hoverable class. As is, none of your Views currently require the z-index feature.

**Special Note:**
You mentioned you didn't quite understand Redux, so I came up with this simple React and Redux example repo to explain how Redux is set up/integrated into a project and its overall flow through the app. [Clone it here](https://github.com/mattcarlotta/React_Redux_Examples), install and run it, and **read all the notes** provided in the files. Play around with the examples and follow the basic flow:

**On initial app load**: 
- Reducers initialize state
- Redux middlewares are intialized 
- A top-level Provider function takes configured store and passes Redux state to any **mounted** and **connected** container-components

**After app loads** (open your browser's console and click the "Click to update counter" link, then click the plus icon and then minus icon to increase/decrease the counter to see a console log of the list below happen in real time): 
- Counter view is loaded 
- A Counter container-component is hooked up to Redux
- User pushes the plus/minus button to trigger an action creator
- Action creator returns a type to the reducers
- Reducers iterate over the type and check to see if it matches any of the cases. If the type matches a case, it updates that particular Redux state accordingly
- This Redux state change then triggers the Counter container-component to re-render with new Redux data