### PR TITLE
Minor visual changes in /logos

### DIFF
--- a/src/styles/logos.scss
+++ b/src/styles/logos.scss
@@ -9,13 +9,17 @@ $link-color: $fus-yellow;
   list-style-type: none;
   text-align: center;
 
+  .active {
+    font-weight: 500;
+  }
+
   .tab {
     margin: 0 2px;
     display: inline;
+    padding: 8px;
+    color: $fus-yellow;
+    cursor: pointer;
 
-    a {
-      padding: 8px;
-    }
   }
 }
 

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -33,15 +33,12 @@ class Logos extends Component {
           <div className='col s12 hide-on-med-and-down'>
             <ul className='tabs'>
               {map(tabs, (tab, tabKey) => (
-                <li className='tab' key={tabKey + 'li'}>
-                  <a
-                    key={tabKey}
-                    href={'#' + tabKey}
-                    className={tabKey === activeTab && 'active'}
-                    onClick={() => this.setState({ activeTab: tabKey })}
-                  >
-                    {tabs[tabKey]}
-                  </a>
+                <li
+                  className={`tab ${tabKey === activeTab && 'active'}`}
+                  key={tabKey + 'li'}
+                  onClick={() => this.setState({ activeTab: tabKey })}
+                >
+                  {tabs[tabKey]}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## Changelog:
1. Added `font-weight: 500` for the active tab in `/logos`. There was nothing indicating on what tab you were on a big screen. Maybe you want to change it to something else.
2. Removed the `<a>` tags in the tabs so now they are plain `<li>` tags doing the same thing. It's visually annoying to see `#something` changing at the end of the URL.
