### PR TITLE
Reduce WET code in Logos view, fix some reactGA warnings, and add rea…

### DIFF
--- a/src/components/ScrollIntoView.js
+++ b/src/components/ScrollIntoView.js
@@ -1,10 +1,20 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router'
+import { initGA, logPageView } from '../utils/analytics'
 
 class ScrollIntoView extends Component {
+  componentWillMount () {
+    if (!window.GA_INTIALIZED) {
+      initGA()
+      window.GA_INTIALIZED = true
+      logPageView()
+    }
+  }
+
   componentDidUpdate (prevProps) {
     if (this.props.location.pathname !== prevProps.location.pathname) {
       this.component.scrollIntoView()
+      logPageView()
     }
   }
 

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -1,6 +1,6 @@
 import '../styles/App.css'
 import '../styles/materialize-grid.css'
-import React, { Component } from 'react'
+import React from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 import injectTapEventPlugin from 'react-tap-event-plugin'
 
@@ -25,49 +25,36 @@ import ServiceRequest from '../views/ServiceRequest'
 import Services from '../views/services'
 import Story from '../views/story'
 import Tutorial from '../views/Tutorial'
-import { initGA } from '../utils/analytics'
 
 injectTapEventPlugin()
 
-class Routes extends Component {
-  componentDidMount () {
-    if (!window.GA_INTIALIZED) {
-      initGA()
-      window.GA_INTIALIZED = true
-    }
-  }
+const Routes = () => {
+  return (
+    <BrowserRouter>
+      <ScrollIntoView>
+        <MuiThemeProvider muiTheme={getMuiTheme(fusTheme)}>
+          <div>
+            <SideNav />
+            <Switch>
+              <Route exact path='/' component={Home} />
 
-  render () {
-    return (
-      <BrowserRouter>
-        <ScrollIntoView>
-          <MuiThemeProvider muiTheme={getMuiTheme(fusTheme)}>
-            <div>
-              <SideNav />
-              <Switch>
-                <Route exact path='/' component={Home} />
-
-                <Route path='/logos' component={Logos} />
-                <Route path='/posters' component={Posters} />
-                <Route path='/letterhead' component={Letterhead} />
-                <Route path='/share-a-story' component={Story} />
-                <Route path='/planning-guide' component={PlanningGuide} />
-                <Route path='/glossary' component={Glossary} />
-                <Route path='/services' component={Services} />
-                <Route
-                  path='/service-request-form'
-                  component={ServiceRequest}
-                />
-                <Route path='/tutorial' component={Tutorial} />
-                <Route path='/poster-videos' component={PosterVideos} />
-                <Route component={NotFound} />
-              </Switch>
-            </div>
-          </MuiThemeProvider>
-        </ScrollIntoView>
-      </BrowserRouter>
-    )
-  }
+              <Route path='/logos' component={Logos} />
+              <Route path='/posters' component={Posters} />
+              <Route path='/letterhead' component={Letterhead} />
+              <Route path='/share-a-story' component={Story} />
+              <Route path='/planning-guide' component={PlanningGuide} />
+              <Route path='/glossary' component={Glossary} />
+              <Route path='/services' component={Services} />
+              <Route path='/service-request-form' component={ServiceRequest} />
+              <Route path='/tutorial' component={Tutorial} />
+              <Route path='/poster-videos' component={PosterVideos} />
+              <Route component={NotFound} />
+            </Switch>
+          </div>
+        </MuiThemeProvider>
+      </ScrollIntoView>
+    </BrowserRouter>
+  )
 }
 
 export default Routes

--- a/src/utils/analytics.js
+++ b/src/utils/analytics.js
@@ -3,6 +3,7 @@ import ReactGA from 'react-ga'
 export const initGA = () => {
   ReactGA.initialize('UA-5819863-23')
 }
+
 export const logPageView = () => {
   ReactGA.set({ page: window.location.pathname })
   ReactGA.pageview(window.location.pathname)

--- a/src/views/Logos.js
+++ b/src/views/Logos.js
@@ -6,7 +6,6 @@ import { Helmet } from 'react-helmet'
 import { logos, tabs } from '../data/logoData.js'
 import MasonryComp from '../components/masonryComp'
 import '../styles/logos.css'
-import { logPageView } from '../utils/analytics'
 import { Tabs, Tab } from 'material-ui/Tabs'
 
 class Logos extends Component {
@@ -15,12 +14,6 @@ class Logos extends Component {
     data: logos,
     type: 'all'
   }
-
-  componentDidMount = () => {
-    logPageView()
-  }
-
-  handleChange = (event, index, value) => this.setState({ activeTab: value })
 
   handleTabChange = value => {
     this.setState({
@@ -55,7 +48,7 @@ class Logos extends Component {
             <SelectField
               floatingLabelText='Logo Type'
               value={this.state.activeTab}
-              onChange={this.handleChange}
+              onChange={(event, index, value) => this.handleTabChange(value)}
               style={{ textAlign: 'left', width: '100%' }}
             >
               {map(tabs, (tab, tabKey) => (


### PR DESCRIPTION
…ctGA to a top-level component that updates on route change

- Logos view had two `this.setState({ activeTab: value })` calls, a simple refactor to reuse one
- Some reactGA warnings -- it seems reactGA wants to load before the component, so changed it from `componentDidMount` to `componentWillMount`
- Added reactGA to a top-level component (ScrollIntoView), which **in theory** (you'll need to test this out to confirm if it works or not), should initialize reactGA and then log the first loaded page. Then on subsequent route changes, it should call `logPageView()` again to log the next page (this secondary call may not be needed since ScrollIntoView always sits on the top, but again, you'll need to test it out). This should, **in theory**, remove the need to import and call `logPageView()` for each view.